### PR TITLE
redact demo key

### DIFF
--- a/server/static/bower_components/iron-ajax/demo/index.html
+++ b/server/static/bower_components/iron-ajax/demo/index.html
@@ -33,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template is="dom-bind" id="app">
       <iron-ajax auto
           url="https://www.googleapis.com/youtube/v3/search"
-          params='{"part":"snippet", "q":"polymer", "key": "AIzaSyAuecFZ9xJXbGDkQYWBmYrtzOGJD-iDIgI", "type": "video"}'
+          params='{"part":"snippet", "q":"polymer", "key": "REDACTED", "type": "video"}'
           handle-as="json"
           last-response="{{ajaxResponse}}"></iron-ajax>
 


### PR DESCRIPTION
https://bluecore.atlassian.net/issues/PROD-78982

Cred is in a forked open-source repo, and this API key appears to be both inactive and not owned by Bluecore. Github scan also confirms the cred is inactive. 